### PR TITLE
moves react and prop-types to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,8 @@
   "devDependencies": {
     "d3plus-dev": "^0.6.18",
     "eslint-plugin-react": "^7.11.1",
+    "prop-types": "^15.6.2",
+    "react": "^15.6.2",
     "rollup-plugin-jsx": "^1.0.3"
   },
   "module": "es/index",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,9 @@
     "d3plus-network": "^0.5.3",
     "d3plus-plot": "^0.8.7",
     "d3plus-priestley": "^0.3.2",
-    "d3plus-viz": "^0.12.12",
+    "d3plus-viz": "^0.12.12"
+  },
+  "peerDependencies": {
     "prop-types": "^15.6.2",
     "react": "^15.6.2"
   },


### PR DESCRIPTION
This PR moves the `react` and `prop-types` keys to the peerDependencies list in the package.json file. This will prevent the installation of multiple react versions when using a version of react higher than 15.
