### PR TITLE
Updates react version on dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "d3plus-viz": "^0.12.51"
   },
   "peerDependencies": {
-    "prop-types": "^15.6.2",
-    "react": "^15.6.2"
+    "prop-types": ">=15.6.2",
+    "react": ">=15.6.2"
   },
   "scripts": {
     "docs": "node bin/docs",
@@ -45,8 +45,8 @@
     "@babel/preset-react": "^7.0.0",
     "d3plus-dev": "^0.7.4",
     "eslint-plugin-react": "^7.11.1",
-    "prop-types": "^15.6.2",
-    "react": "^15.6.2"
+    "prop-types": ">=15.6.2",
+    "react": ">=15.6.2"
   },
   "module": "es/index",
   "sideEffects": false,


### PR DESCRIPTION
Some package managers complain when they see the project uses `react@16.x`, but the peerDependencies specify `react@15.x`.

### Description
Updates `react` and `prop-types` versions to allow any version >=15.6.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
